### PR TITLE
Replace `qs` with zero-dependency & Typesafe  `neoqs`

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,12 +79,11 @@
     "@poppinss/macroable": "^1.0.2",
     "@poppinss/multiparty": "^2.0.1",
     "@poppinss/utils": "^6.7.3",
-    "@types/qs": "^6.9.15",
     "bytes": "^3.1.2",
     "file-type": "^19.0.0",
     "inflation": "^2.1.0",
     "media-typer": "^1.1.0",
-    "qs": "^6.12.1",
+    "neoqs": "6.12.4",
     "raw-body": "^2.5.2"
   },
   "peerDependencies": {

--- a/src/parsers/form.ts
+++ b/src/parsers/form.ts
@@ -9,7 +9,8 @@
 
 import raw from 'raw-body'
 import inflate from 'inflation'
-import qs, { IParseOptions } from 'qs'
+import * as qs from 'neoqs'
+
 import type { IncomingMessage } from 'node:http'
 import { BodyParserFormConfig } from '../types.js'
 
@@ -32,7 +33,7 @@ export async function parseForm(req: IncomingMessage, options: Partial<BodyParse
   /**
    * Shallow clone query string options
    */
-  const queryStringOptions: IParseOptions = Object.assign({}, normalizedOptions.queryString)
+  const queryStringOptions = Object.assign({}, normalizedOptions.queryString)
 
   /**
    * Mimicing behavior of


### PR DESCRIPTION
PR inspired by the es tooling ecosystem cleanup initiative on github https://github.com/es-tooling/ecosystem-cleanup

zero-dep, typescript safe alternative to qs

https://deptree.rschristian.dev/?q=qs
https://deptree.rschristian.dev/?q=neoqs

### ❓ Type of change

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
- Replaced 1:1 package with typesafe & zero dep alternative 

