### PR TITLE
Add support for completely disabling multipart request handling

### DIFF
--- a/src/bindings/request.ts
+++ b/src/bindings/request.ts
@@ -90,7 +90,7 @@ Request.macro(
 Request.macro('allFiles', function allFiles(this: Request) {
   if (!this.__raw_files) {
     throw new RuntimeException(
-      'Cannot read files. Make sure the bodyparser middleware is registered'
+      'Cannot read files. Make sure the bodyparser middleware is registered and enabled'
     )
   }
 

--- a/src/bodyparser_middleware.ts
+++ b/src/bodyparser_middleware.ts
@@ -140,6 +140,13 @@ export class BodyParserMiddleware {
     if (this.#isType(ctx.request, multipartConfig.types)) {
       debug('detected multipart request "%s:%s"', requestMethod, requestUrl)
 
+      if (!multipartConfig.enabled) {
+        throw new Exception('request content-type not supported', {
+          status: 415,
+          code: 'E_REQUEST_UNSUPPORTED_MEDIA_TYPE',
+        })
+      }
+
       ctx.request.multipart = new Multipart(ctx, {
         maxFields: multipartConfig.maxFields,
         limit: multipartConfig.limit,

--- a/src/define_config.ts
+++ b/src/define_config.ts
@@ -48,6 +48,7 @@ export function defineConfig(config: BodyParserOptionalConfig): BodyParserConfig
     },
 
     multipart: {
+      enabled: true,
       autoProcess: true,
       processManually: [],
       encoding: 'utf-8',

--- a/src/types.ts
+++ b/src/types.ts
@@ -63,6 +63,7 @@ export type BodyParserRawConfig = BodyParserBaseConfig
  * Parser config for parsing multipart requests
  */
 export type BodyParserMultipartConfig = BodyParserBaseConfig & {
+  enabled: boolean
   autoProcess: boolean | string[]
   maxFields: number
   processManually: string[]

--- a/tests/body_parser.spec.ts
+++ b/tests/body_parser.spec.ts
@@ -201,6 +201,44 @@ test.group('BodyParser Middleware | form data', () => {
     })
   })
 
+  test('abort when multipart is not enabled', async ({ assert, cleanup }) => {
+    const server = createServer(async (req, res) => {
+      const request = new RequestFactory().merge({ req, res }).create()
+      const response = new ResponseFactory().merge({ req, res }).create()
+      const ctx = new HttpContextFactory().merge({ request, response }).create()
+      const middleware = new BodyParserMiddlewareFactory()
+        .merge({
+          multipart: {
+            enabled: false,
+          },
+        })
+        .create()
+
+      try {
+        await middleware.handle(ctx, async () => {})
+      } catch (error) {
+        res.writeHead(error.status)
+        res.end(error.message)
+      }
+    })
+    cleanup(() => {
+      server.close()
+    })
+
+    await new Promise<void>((resolve) => server.listen(3333, 'localhost', () => resolve()))
+
+    const response = await fetch('http://localhost:3333', {
+      method: 'POST',
+      headers: {
+        'Content-type': `multipart/form-data; boundary=9d01a3fb93deedb4d0a81389271d097f28fd67e2fcbff2932befc0458ad7`,
+      },
+      body: '--9d01a3fb93deedb4d0a81389271d097f28fd67e2fcbff2932befc0458ad7\x0d\x0aContent-Disposition: form-data; name="test"; filename="csv_files/test.csv"\x0d\x0aContent-Type: application/octet-stream\x0d\x0a\x0d\x0atest123',
+    })
+
+    assert.equal(response.status, 415)
+    assert.equal(await response.text(), 'request content-type not supported')
+  })
+
   test('abort when multipart body is invalid', async ({ assert, cleanup }) => {
     const server = createServer(async (req, res) => {
       const request = new RequestFactory().merge({ req, res }).create()


### PR DESCRIPTION
As discussed on discord, by the multipart request handling always being enabled, there can be security implications. This adds a `multipart.enabled` option, which defaults to `true`, which allows disabling handling for multipart requests.

If `multipart.enabled === false` then a multipart request is rejected immediately with a [HTTP 514 UNSUPPORTED_MEDIA_TYPE](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/415) response. As mentioned in that documentation, we could also set the `Accept-Post` / `Accept-Patch` header to indicate which content-types are supported by the server, however, this would need something specific in `Exception` class from poppins.

### 🔗 Linked issue

Discussed with @thetutlage on discord today.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This allows people using Adonis Framework to improve the security of their servers by allowing them to completely disable multipart request handling. Previously you needed a [custom middleware](https://github.com/ThisIsMissEm/annotations-service/blob/main/app/middleware/multipart_middleware.ts) to handle this.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion. — n/a
- [x] I have updated the documentation accordingly.
