### PR TITLE
fix: use caught error variable in reportProgress catch block

### DIFF
--- a/src/multipart/main.ts
+++ b/src/multipart/main.ts
@@ -208,7 +208,7 @@ export class Multipart {
 
         try {
           await partHandler.reportProgress(line, lineLength)
-        } catch (err) {
+        } catch (error) {
           part.emit('error', error)
           this.abort(error)
         }


### PR DESCRIPTION
### 🔗 Linked issue

[76](https://github.com/adonisjs/bodyparser/issues/76)

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The catch block was using `error` (from validateProcessedBytes) instead of
`err` (the caught exception), causing undefined to be emitted when
reportProgress throws, which crashes the error handler.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
