### PR TITLE
fix: mismatch catch err variable used

### DIFF
--- a/src/multipart/main.ts
+++ b/src/multipart/main.ts
@@ -109,8 +109,8 @@ export class Multipart {
     featureFlags: {
       mergeFieldsAndFiles: boolean
     } = {
-        mergeFieldsAndFiles: false,
-      }
+      mergeFieldsAndFiles: false,
+    }
   ) {
     this.#ctx = ctx
     this.#config = config

--- a/src/multipart/main.ts
+++ b/src/multipart/main.ts
@@ -109,8 +109,8 @@ export class Multipart {
     featureFlags: {
       mergeFieldsAndFiles: boolean
     } = {
-      mergeFieldsAndFiles: false,
-    }
+        mergeFieldsAndFiles: false,
+      }
   ) {
     this.#ctx = ctx
     this.#config = config
@@ -226,8 +226,8 @@ export class Multipart {
         try {
           await partHandler.reportProgress(line, lineLength)
         } catch (err) {
-          part.emit('error', error)
-          this.abort(error)
+          part.emit('error', err)
+          this.abort(err)
         }
       })
 
@@ -286,7 +286,7 @@ export class Multipart {
   #finish(newState: 'error' | 'success') {
     if (this.state === 'idle' || this.state === 'processing') {
       this.state = newState
-      ;(this.#ctx.request as any)['__raw_files'] = this.#files.get()
+        ; (this.#ctx.request as any)['__raw_files'] = this.#files.get()
       this.#ctx.request.setInitialBody(this.#fields.get())
     }
   }

--- a/src/multipart/main.ts
+++ b/src/multipart/main.ts
@@ -286,7 +286,7 @@ export class Multipart {
   #finish(newState: 'error' | 'success') {
     if (this.state === 'idle' || this.state === 'processing') {
       this.state = newState
-        ; (this.#ctx.request as any)['__raw_files'] = this.#files.get()
+      ;(this.#ctx.request as any)['__raw_files'] = this.#files.get()
       this.#ctx.request.setInitialBody(this.#fields.get())
     }
   }


### PR DESCRIPTION
### 🔗 Linked issue

[76](https://github.com/adonisjs/bodyparser/issues/76)

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The catch block was using `error` (from validateProcessedBytes) instead of
`err` (the caught exception), causing undefined to be emitted when
reportProgress throws, which crashes the error handler.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.