### PR TITLE
fix: handle gzip request bodies without invalid length checks

### DIFF
--- a/src/parsers/text.ts
+++ b/src/parsers/text.ts
@@ -25,7 +25,6 @@ export function prepareTextParserOptions(options: Partial<BodyParserRawConfig>):
   return {
     encoding: options.encoding ?? 'utf8',
     limit: options.limit ?? '56kb',
-    length: 0,
   }
 }
 

--- a/tests/parsers/json.spec.ts
+++ b/tests/parsers/json.spec.ts
@@ -10,6 +10,7 @@
 import supertest from 'supertest'
 import { test } from '@japa/runner'
 import { createServer } from 'node:http'
+import { gzipSync } from 'node:zlib'
 import { parseJSON, prepareJSONParserOptions } from '../../src/parsers/json.ts'
 
 test.group('JSON parser', () => {
@@ -51,6 +52,59 @@ test.group('JSON parser', () => {
       .expect(415)
 
     assert.equal(text, 'Unsupported Content-Encoding: invalid')
+  })
+
+  test('parse valid gzip request body', async ({ assert }) => {
+    const server = createServer(async (req, res) => {
+      try {
+        const body = await parseJSON(req, prepareJSONParserOptions({}))
+        res.writeHead(200, { 'content-type': 'application/json' })
+        res.end(JSON.stringify(body))
+      } catch (error) {
+        res.writeHead(error.status || 500, { 'content-type': 'application/json' })
+        res.end(
+          JSON.stringify({
+            message: error.message,
+            status: error.status,
+            code: error.code,
+            type: error.type,
+          })
+        )
+      }
+    })
+
+    const payload = gzipSync(Buffer.from(JSON.stringify({ foo: { bar: 'baz' } })))
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+    try {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        throw new Error('Failed to resolve test server address')
+      }
+
+      const response = await fetch(`http://127.0.0.1:${address.port}/`, {
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'content-encoding': 'gzip',
+        },
+        body: payload,
+      })
+
+      assert.equal(response.status, 200)
+      assert.deepEqual(await response.json(), {
+        parsed: { foo: { bar: 'baz' } },
+        raw: JSON.stringify({ foo: { bar: 'baz' } }),
+      })
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) return reject(error)
+
+          resolve()
+        })
+      })
+    }
   })
 
   test('return empty string when content-length=0 and strict is false', async ({ assert }) => {

--- a/tests/parsers/raw.spec.ts
+++ b/tests/parsers/raw.spec.ts
@@ -10,6 +10,7 @@
 import supertest from 'supertest'
 import { test } from '@japa/runner'
 import { createServer } from 'node:http'
+import { gzipSync } from 'node:zlib'
 import { parseText, prepareTextParserOptions } from '../../src/parsers/text.ts'
 
 test.group('Raw parser', () => {
@@ -22,6 +23,42 @@ test.group('Raw parser', () => {
 
     const { text } = await supertest(server).post('/').send('Hello World!').expect(200)
     assert.equal(text, 'Hello World!')
+  })
+
+  test('inflate gzip request body', async ({ assert }) => {
+    const server = createServer(async (req, res) => {
+      const body = await parseText(req, prepareTextParserOptions({}))
+      res.writeHead(200)
+      res.end(body)
+    })
+
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+
+    try {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        throw new Error('Failed to resolve test server address')
+      }
+
+      const response = await fetch(`http://127.0.0.1:${address.port}/`, {
+        method: 'POST',
+        headers: {
+          'content-encoding': 'gzip',
+        },
+        body: gzipSync(Buffer.from('Hello World!')),
+      })
+
+      assert.equal(response.status, 200)
+      assert.equal(await response.text(), 'Hello World!')
+    } finally {
+      await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+          if (error) return reject(error)
+
+          resolve()
+        })
+      })
+    }
   })
 
   test('fail with 415 when content encoding is invalid', async ({ assert }) => {


### PR DESCRIPTION
## Summary

This PR fixes gzip request body parsing in `@adonisjs/bodyparser`.

Compressed request bodies could fail with:

`request size did not match content length`

## Cause

The text parser was passing `length: 0` to `raw-body` by default.

For `identity` requests, this value was later replaced with the actual `Content-Length`, but for gzip-compressed requests it remained `0`.

`raw-body` treats any defined `length` as a strict expected size, so valid gzip payloads were rejected because the received decompressed body size did not match `0`.

## Fix

Stop passing a default `length` value.

The parser now only provides a length when there is a real value to forward, which avoids the invalid size check for compressed request bodies while preserving the existing behavior for uncompressed requests.

## Tests

Added regression coverage for gzip payloads in:
- JSON parser
- Raw parser

These tests verify that valid gzip-compressed request bodies are correctly decompressed and parsed.
